### PR TITLE
Ignoring package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 node_modules
+package-lock.json


### PR DESCRIPTION
Any update of the dependencies will create a package-lock. This PR adds the package-lock to `.gitignore` in order to prevent accidental commits of it.