### PR TITLE
Loading .min.js as that file is quicker loaded.

### DIFF
--- a/prism.js
+++ b/prism.js
@@ -77,7 +77,7 @@ function higlight(text, language) {
     var grammar = prism.languages[language];
     if (!grammar) {
         try {
-            require('prismjs/components/prism-' + language);
+            require('prismjs/components/prism-' + language + '.min.js');
             grammar = prism.languages[language];
         } catch(e) {
             throw new Error('Uknown language ' + language);


### PR DESCRIPTION
The `min.js` files that are published with prism are smaller and usually quicker to load for node.js. This PR loads these files instead of the regular files.