### PR TITLE
Fixing typo in error message and displaying the supported languages.

### DIFF
--- a/prism.js
+++ b/prism.js
@@ -80,7 +80,7 @@ function higlight(text, language) {
             require('prismjs/components/prism-' + language);
             grammar = prism.languages[language];
         } catch(e) {
-            throw new Error('Uknown language ' + language);
+            throw new Error('Unknown language ' + language + ', available languages are ' + Object.keys(require('prismjs/components.js').languages).join(', '));
         }
     }
     var tokens = prism.tokenize(text, grammar);


### PR DESCRIPTION
I noticed a typo if a language is missing (`Uknown`). This PR fixes that typo and adds more information about the available languages.